### PR TITLE
Improved Cypher entry box

### DIFF
--- a/Neo4jPowerBiConnector/Neo4j.mproj
+++ b/Neo4jPowerBiConnector/Neo4j.mproj
@@ -11,15 +11,16 @@
     <AllowNativeQuery>False</AllowNativeQuery>
     <AsAction>False</AsAction>
     <FastCombine>False</FastCombine>
-    <ClearLog>False</ClearLog>
+    <ClearLog>True</ClearLog>
     <ShowEngineTraces>False</ShowEngineTraces>
-    <ShowUserTraces>False</ShowUserTraces>
+    <ShowUserTraces>True</ShowUserTraces>
     <LegacyRedirects>False</LegacyRedirects>
     <SuppressRowErrors>False</SuppressRowErrors>
     <SuppressCellErrors>False</SuppressCellErrors>
     <MaxRows>1000</MaxRows>
     <ExtensionProject>Yes</ExtensionProject>
     <Name>Neo4j</Name>
+    <ThrowOnFoldingFailure>False</ThrowOnFoldingFailure>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>false</DebugSymbols>

--- a/Neo4jPowerBiConnector/Neo4j.pq
+++ b/Neo4jPowerBiConnector/Neo4j.pq
@@ -26,9 +26,9 @@ ExecuteCypherType = type function (
             Documentation.SampleValues = {"MATCH (n) RETURN n", "MATCH (n) RETURN COUNT(n)"}
     ]),
     optional scheme as (type text meta [
-		    Documentation.FieldDescription = "The scheme to connect to your Neo4j instance",
+            Documentation.FieldDescription = "The scheme to connect to your Neo4j instance",
             Documentation.SampleValues = {"http", "https"},
-		    Documentation.AllowedValues = { "http", "https" }
+            Documentation.AllowedValues = { "http", "https" }
     ]),
     optional address as (type text meta [
             Documentation.FieldCaption = "Address",
@@ -44,11 +44,11 @@ ExecuteCypherType = type function (
             Documentation.FieldCaption = "Neo4j Version",
             Documentation.FieldDescription = "The version of the server you are connecting to.",
             Documentation.SampleValues = {3.5, 4.0},
-            Documentation.AllowedValues = {3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 4.0}
+            Documentation.AllowedValues = {3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 4.0, 4.1}
     ]),
     optional databaseName as (type text meta [
             Documentation.FieldCaption = "Database Name",
-            Documentation.FieldDescription = "The name of your database (only used for a 4.0 DB, if unsure, use neo4j)",
+            Documentation.FieldDescription = "The name of your database (only used for a 4.x DB, if unsure, use neo4j)",
             Documentation.SampleValues = {"neo4j", "hr"}
     ]),
     optional timeout as (type number meta [
@@ -57,7 +57,7 @@ ExecuteCypherType = type function (
             Documentation.SampleValues = {30}
     ])
 ) as table meta [
-		Documentation.Name = "Execute Cypher - Output",
+        Documentation.Name = "Execute Cypher - Output",
         Documentation.LongDescription = "Provides the response of the query in a Json document"];
 
 ///
@@ -65,10 +65,10 @@ ExecuteCypherType = type function (
 /// taking into account the comments from 'Will' - to get the column output using the names returned from the query
 ///
 ExecuteCypherImpl = (
-			cypher as text,
+            cypher as text,
             optional scheme as nullable text,
-			optional address as nullable text, 
-			optional port as nullable number,
+            optional address as nullable text, 
+            optional port as nullable number,
             optional neo4jVersion as nullable number,
             optional databaseName as nullable text,
             optional timeout as nullable number) as table =>
@@ -79,16 +79,16 @@ let
         Timeout=#duration(0,0,0,Neo4j.GetTimeout(timeout))
     ]),
     _json = Json.Document(_source),
-	_results = _json[results],
-	_results1 = _results{0},
-	_data = _results1[data],
-	_columns = _results1[columns],
-	_tabledResults = Table.FromList(_data, Splitter.SplitByNothing(), null, null, ExtraValues.Error),
-	_rows = Table.ExpandRecordColumn(_tabledResults, "Column1", {"row"}, {"Column1.row"}),
-	_column1Row = _rows[Column1.row],
-	table = Table.FromRows(_column1Row, _columns)
+    _results = _json[results],
+    _results1 = _results{0},
+    _data = _results1[data],
+    _columns = _results1[columns],
+    _tabledResults = Table.FromList(_data, Splitter.SplitByNothing(), null, null, ExtraValues.Error),
+    _rows = Table.ExpandRecordColumn(_tabledResults, "Column1", {"row"}, {"Column1.row"}),
+    _column1Row = _rows[Column1.row],
+    table = Table.FromRows(_column1Row, _columns)
 in 
-	table;
+    table;
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 // Private Functions
@@ -98,11 +98,11 @@ in
 //
 DefaultRequestHeaders = [
     #"Authorization" = "Basic " & Neo4j.Encode(Extension.CurrentCredential()[Username], Extension.CurrentCredential()[Password]),
-	#"Content-Type"="application/json"
+    #"Content-Type"="application/json"
 ];
 
 ImplicitRequestHeaders = [
-	#"Content-Type"="application/json"
+    #"Content-Type"="application/json"
 ];
 
 //
@@ -114,16 +114,16 @@ ImplicitRequestHeaders = [
 //  databaseName: neo4j
 //
 Neo4j.DefaultUri = (optional scheme as nullable text, optional address as nullable text, optional port as nullable number, optional neo4jVersion as nullable number, optional databaseName as nullable text) =>
-	let
+    let
         _version = if(neo4jVersion) is null then 3.5 else neo4jVersion,
         _databaseName = if(databaseName) is null then "neo4j" else databaseName,
         _transactionEndPoint = if(_version) < 4.0 then "db/data/transaction/commit" else "db/" & _databaseName & "/tx",
-		_port = if (port) is null then 7474 else port,
-		_address = if address is null then "localhost." else address,
-		_scheme = if scheme is null then "http" else scheme,
-		uri = _scheme & "://" & _address & ":" & Text.From(_port) & "/" & _transactionEndPoint
-	in
-		uri;
+        _port = if (port) is null then 7474 else port,
+        _address = if address is null then "localhost." else address,
+        _scheme = if scheme is null then "http" else scheme,
+        uri = _scheme & "://" & _address & ":" & Text.From(_port) & "/" & _transactionEndPoint
+    in
+        uri;
 
 //
 // Encodes a username/password into a combined base64 string of {user}:{password}
@@ -159,13 +159,15 @@ Neo4j.GetTimeout = (timeout as nullable number) =>
 // Connector definition, allows access via User/Password combinations and Anonymous (Implicit)
 //
 Neo4j = [
+    TestConnection = (datasourcePath) => {"Neo4j.ExecuteCypher"},
+
     Authentication = [
         UsernamePassword = [
             Label = "Neo4j Authentication",
             UsernameLabel = "Username",
             PasswordLabel = "Password"
         ],
-		Anonymous = []
+        Anonymous = []
     ],
     Label = Extension.LoadString("DataSourceLabel")
 ];

--- a/Neo4jPowerBiConnector/Neo4j.pq
+++ b/Neo4jPowerBiConnector/Neo4j.pq
@@ -46,7 +46,7 @@ ExecuteCypherType = type function (
             Documentation.FieldCaption = "Neo4j Version",
             Documentation.FieldDescription = "The version of the server you are connecting to.",
             Documentation.SampleValues = {3.5, 4.0},
-            Documentation.AllowedValues = {3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 4.0, 4.1}
+            Documentation.AllowedValues = {3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 4.0, 4.1, 4.2, 4.3}
     ]),
     optional databaseName as (type text meta [
             Documentation.FieldCaption = "Database Name",
@@ -74,7 +74,45 @@ ExecuteCypherImpl = (
             optional neo4jVersion as nullable number,
             optional databaseName as nullable text,
             optional timeout as nullable number) as table =>
+try
+    let
+        x = Diagnostics.Trace(TraceLevel.Error, "ExecuteCypherImpl", ()=>"Test", true),
+        _binaryCypher = Neo4j.CypherToM(cypher),
+        _source = Web.Contents(Neo4j.DefaultUri(scheme, address, port, neo4jVersion, databaseName), [
+            Headers = if Extension.CurrentCredential()[AuthenticationKind] = "Implicit" then ImplicitRequestHeaders else DefaultRequestHeaders,
+            Content = _binaryCypher,
+            Timeout=#duration(0,0,0,Neo4j.GetTimeout(timeout))
+        ]),
+        _json = Json.Document(_source),
+        _results = _json[results],
+        _results1 = _results{0},
+        _data = _results1[data],
+        _columns = _results1[columns],
+        _tabledResults = Table.FromList(_data, Splitter.SplitByNothing(), null, null, ExtraValues.Error),
+        _rows = Table.ExpandRecordColumn(_tabledResults, "Column1", {"row"}, {"Column1.row"}),
+        _column1Row = _rows[Column1.row],
+        table = Table.FromRows(_column1Row, _columns)
+    in 
+        table
+otherwise
+    let 
+        message = Text.Format("Unable to execute '#[cypher]'", [cypher = Neo4j.CleanCyper(cypher)])
+    in 
+        Diagnostics.Trace(TraceLevel.Error, message, () => error message, true);
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+// Private Functions
+
+ExecuteCypherImplPrv = (
+            cypher as text,
+            optional scheme as nullable text,
+            optional address as nullable text, 
+            optional port as nullable number,
+            optional neo4jVersion as nullable number,
+            optional databaseName as nullable text,
+            optional timeout as nullable number) as table =>
 let
+    x = Diagnostics.Trace(TraceLevel.Error, "ExecuteCypherImpl", ()=>"Test", true),
     _source = Web.Contents(Neo4j.DefaultUri(scheme, address, port, neo4jVersion, databaseName), [
         Headers = if Extension.CurrentCredential()[AuthenticationKind] = "Implicit" then ImplicitRequestHeaders else DefaultRequestHeaders,
         Content = Neo4j.CypherToM(cypher),
@@ -89,11 +127,11 @@ let
     _rows = Table.ExpandRecordColumn(_tabledResults, "Column1", {"row"}, {"Column1.row"}),
     _column1Row = _rows[Column1.row],
     table = Table.FromRows(_column1Row, _columns)
+    
 in 
     table;
 
-//////////////////////////////////////////////////////////////////////////////////////////////
-// Private Functions
+
 
 //
 // Generates the default request headers needed for Neo4j to work
@@ -141,13 +179,26 @@ Neo4j.Encode = (user as text, password as text) =>
 //
 Neo4j.CypherToM = (cypher as text) =>
     let 
+        cleanCypher = Neo4j.CleanCyper(cypher),
         binary = Text.ToBinary("{
                     ""statements"" : [ {
-                    ""statement"" : "" " & cypher & " ""} ]
+                    ""statement"" : "" " & cleanCypher & " ""} ]
                     }")
     in
         binary;
 
+//
+// Clean the Cypher - removing CRLF characters
+//
+Neo4j.CleanCyper = (cypher as text) =>
+    let 
+        cleanCypher = Text.Replace(Text.Replace(Text.Replace(Text.Replace(cypher, "#(cr)", " "), "#(lf)", " "), "\u000d", " "), "\u000a", " ")
+    in 
+        cleanCypher;
+
+//
+// Gets the default timeout (30s) or the value set.
+//
 Neo4j.GetTimeout = (timeout as nullable number) =>
     let 
         _timeout = if(timeout) is null then 30 else timeout

--- a/Neo4jPowerBiConnector/Neo4j.pq
+++ b/Neo4jPowerBiConnector/Neo4j.pq
@@ -159,8 +159,18 @@ Neo4j.GetTimeout = (timeout as nullable number) =>
 // Connector definition, allows access via User/Password combinations and Anonymous (Implicit)
 //
 Neo4j = [
-    TestConnection = (datasourcePath) => {"Neo4j.ExecuteCypher"},
-
+    TestConnection = (datasourcePath) => 
+        let
+            json = Json.Document(datasourcePath),
+            cypher = json[cypher],
+            scheme = json[scheme],
+            address = json[address],
+            port = json[port],
+            neo4jVersion = json[neo4jVersion],
+            databaseName = json[databaseName],
+            timeout  = json[timeout]
+        in
+            {"Neo4j.ExecuteCypher", cypher, scheme, address, port, neo4jVersion, databaseName, timeout },
     Authentication = [
         UsernamePassword = [
             Label = "Neo4j Authentication",

--- a/Neo4jPowerBiConnector/Neo4j.pq
+++ b/Neo4jPowerBiConnector/Neo4j.pq
@@ -23,6 +23,8 @@ ExecuteCypherType = type function (
     cypher as (type text meta [
             Documentation.FieldCaption = "Cypher",
             Documentation.FieldDescription = "Enter your Cypher query here",
+            Formatting.IsMultiLine = true,
+            Formatting.IsCode = true,
             Documentation.SampleValues = {"MATCH (n) RETURN n", "MATCH (n) RETURN COUNT(n)"}
     ]),
     optional scheme as (type text meta [

--- a/Neo4jPowerBiConnector/Neo4j.pq
+++ b/Neo4jPowerBiConnector/Neo4j.pq
@@ -44,8 +44,8 @@ ExecuteCypherType = type function (
     ]),
     optional neo4jVersion as (type number meta [
             Documentation.FieldCaption = "Neo4j Version",
-            Documentation.FieldDescription = "The version of the server you are connecting to.",
-            Documentation.SampleValues = {3.5, 4.0},
+            Documentation.FieldDescription = "The version of the server you are connecting to (default is 4.2).",
+            Documentation.SampleValues = {3.5, 4.2},
             Documentation.AllowedValues = {3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 4.0, 4.1, 4.2, 4.3}
     ]),
     optional databaseName as (type text meta [
@@ -74,15 +74,8 @@ ExecuteCypherImpl = (
             optional neo4jVersion as nullable number,
             optional databaseName as nullable text,
             optional timeout as nullable number) as table =>
-try
     let
-        x = Diagnostics.Trace(TraceLevel.Error, "ExecuteCypherImpl", ()=>"Test", true),
-        _binaryCypher = Neo4j.CypherToM(cypher),
-        _source = Web.Contents(Neo4j.DefaultUri(scheme, address, port, neo4jVersion, databaseName), [
-            Headers = if Extension.CurrentCredential()[AuthenticationKind] = "Implicit" then ImplicitRequestHeaders else DefaultRequestHeaders,
-            Content = _binaryCypher,
-            Timeout=#duration(0,0,0,Neo4j.GetTimeout(timeout))
-        ]),
+        _source = Neo4j.ExecuteRestCall(cypher, scheme, address, port, neo4jVersion, databaseName, timeout),
         _json = Json.Document(_source),
         _results = _json[results],
         _results1 = _results{0},
@@ -93,44 +86,34 @@ try
         _column1Row = _rows[Column1.row],
         table = Table.FromRows(_column1Row, _columns)
     in 
-        table
-otherwise
-    let 
-        message = Text.Format("Unable to execute '#[cypher]'", [cypher = Neo4j.CleanCyper(cypher)])
-    in 
-        Diagnostics.Trace(TraceLevel.Error, message, () => error message, true);
+        table;
 
+  
 //////////////////////////////////////////////////////////////////////////////////////////////
 // Private Functions
 
-ExecuteCypherImplPrv = (
+Neo4j.ExecuteRestCall = (
             cypher as text,
             optional scheme as nullable text,
             optional address as nullable text, 
             optional port as nullable number,
             optional neo4jVersion as nullable number,
             optional databaseName as nullable text,
-            optional timeout as nullable number) as table =>
-let
-    x = Diagnostics.Trace(TraceLevel.Error, "ExecuteCypherImpl", ()=>"Test", true),
-    _source = Web.Contents(Neo4j.DefaultUri(scheme, address, port, neo4jVersion, databaseName), [
-        Headers = if Extension.CurrentCredential()[AuthenticationKind] = "Implicit" then ImplicitRequestHeaders else DefaultRequestHeaders,
-        Content = Neo4j.CypherToM(cypher),
-        Timeout=#duration(0,0,0,Neo4j.GetTimeout(timeout))
-    ]),
-    _json = Json.Document(_source),
-    _results = _json[results],
-    _results1 = _results{0},
-    _data = _results1[data],
-    _columns = _results1[columns],
-    _tabledResults = Table.FromList(_data, Splitter.SplitByNothing(), null, null, ExtraValues.Error),
-    _rows = Table.ExpandRecordColumn(_tabledResults, "Column1", {"row"}, {"Column1.row"}),
-    _column1Row = _rows[Column1.row],
-    table = Table.FromRows(_column1Row, _columns)
-    
-in 
-    table;
-
+            optional timeout as nullable number) as binary =>
+try
+    let
+        content = Web.Contents(Neo4j.DefaultUri(scheme, address, port, neo4jVersion, databaseName), [
+            Headers = if Extension.CurrentCredential()[AuthenticationKind] = "Implicit" then ImplicitRequestHeaders else DefaultRequestHeaders,
+            Content = Neo4j.CypherToM(cypher),
+            Timeout=#duration(0,0,0,Neo4j.GetTimeout(timeout))
+        ])    
+    in 
+        content
+otherwise
+    let 
+        message = Text.Format("Error executing the call against the database.#(cr)#(lf)Cypher was: '#[cypher]'#(cr)#(lf)NB. Cypher shown is how it was formatted to send to Neo4j.", [cypher=Neo4j.CleanCyper(cypher)])
+    in 
+        Diagnostics.Trace(TraceLevel.Error, message, () => error message, true);
 
 
 //
@@ -155,7 +138,7 @@ ImplicitRequestHeaders = [
 //
 Neo4j.DefaultUri = (optional scheme as nullable text, optional address as nullable text, optional port as nullable number, optional neo4jVersion as nullable number, optional databaseName as nullable text) =>
     let
-        _version = if(neo4jVersion) is null then 3.5 else neo4jVersion,
+        _version = if(neo4jVersion) is null then 4.2 else neo4jVersion,
         _databaseName = if(databaseName) is null then "neo4j" else databaseName,
         _transactionEndPoint = if(_version) < 4.0 then "db/data/transaction/commit" else "db/" & _databaseName & "/tx",
         _port = if (port) is null then 7474 else port,

--- a/Neo4jPowerBiConnector/Neo4j.query.pq
+++ b/Neo4jPowerBiConnector/Neo4j.query.pq
@@ -14,8 +14,7 @@ in
 
 
 let 
-    result = Neo4j.ExecuteCypher("MATCH (n:Movie)
-    RETURN n", "http", "localhost.", 7474, 4.2, "neo4j", 30)
+    result = Neo4j.ExecuteCypher("MATCH (n:Movie) RETURN n", "http", "localhost.", 7474, 4.2, "neo4j", 30)
 in
     result
 

--- a/Neo4jPowerBiConnector/Neo4j.query.pq
+++ b/Neo4jPowerBiConnector/Neo4j.query.pq
@@ -7,12 +7,28 @@ in
 */
 /*
 let 
-	result = Neo4j.GetCountOfNodes()
+    result = Neo4j.GetCountOfNodes()
 in
-	result
+    result
 */
 
+
 let 
-	result = Neo4j.ExecuteCypher("MATCH (n) RETURN COUNT(n)", null, "localhost", 8866)
+    result = Neo4j.ExecuteCypher("MATCH (n:Movie)
+    RETURN n", "http", "localhost.", 7474, 4.2, "neo4j", 30)
 in
-	result
+    result
+
+    /*
+let 
+    result = Neo4j.ExecuteCypher("MATCH (n) RETURN COUNT(n)", "http", "Server2019Blog", 7474, 4.2, "neo4j", 30)
+in
+    result
+    */
+
+/*
+let 
+    result = Neo4j.ExecuteCypher("MATCH (n) RETURN COUNT(n)", "http", "localhost", 7474, 4.1, "neo4j", 30)
+in
+    result
+*/

--- a/README.md
+++ b/README.md
@@ -16,9 +16,13 @@ Pretty much what it says on the tin.
 
 All releases are available on the [Releases](https://github.com/cskardon/Neo4jDataConnectorForPowerBi/releases) page.
 
-## Versions!
+## Versions
 
-* 1.0 = Initial release
-* 1.1 = Bug fix to get it working with Neo4j 4.0 MR2 (and probably onwards)
-* 1.2 = Neo4j `4.0` release - should work with `3.x` and `4.x`
-* 1.3 = Adding `Timeout` settings for longer running queries
+* [1.0](https://github.com/cskardon/Neo4jDataConnectorForPowerBi/releases/tag/1.0.0) = Initial release
+* [1.1](https://github.com/cskardon/Neo4jDataConnectorForPowerBi/releases/tag/1.1.0) = Bug fix to get it working with Neo4j 4.0 MR2 (and probably onwards)
+* [1.2](https://github.com/cskardon/Neo4jDataConnectorForPowerBi/releases/tag/1.2.0) = Neo4j `4.0` release - should work with `3.x` and `4.x`
+* [1.3](https://github.com/cskardon/Neo4jDataConnectorForPowerBi/releases/tag/1.3.0) = Adding `Timeout` settings for longer running queries
+
+## Beta Versions
+
+* [1.4beta](https://github.com/cskardon/Neo4jDataConnectorForPowerBi/releases/tag/1.4.0-beta) = Adding Auto-refresh support -- [Issue #1](https://github.com/cskardon/Neo4jDataConnectorForPowerBi/issues/1)


### PR DESCRIPTION
This isn't *auto-refresh* (despite what the branch is called) but other changes that make it easier to use the connector (improved logging, multi-line Cypher entry) and it is now defaulted to `4.2` as the Neo4j version.

In practical senses, you will only need to update the version _if_ you are using a 3.x version. If you are on `4.0`, `4.1` or even `4.3` (??) the `4` is the only bit that matters.