### PR TITLE
Correctly escapes double quotes

### DIFF
--- a/Neo4jPowerBiConnector/Neo4j.pq
+++ b/Neo4jPowerBiConnector/Neo4j.pq
@@ -177,7 +177,7 @@ Neo4j.CypherToM = (cypher as text) =>
 //
 Neo4j.CleanCyper = (cypher as text) =>
     let 
-        cleanCypher = Text.Replace(Text.Replace(Text.Replace(Text.Replace(cypher, "#(cr)", " "), "#(lf)", " "), "\u000d", " "), "\u000a", " ")
+        cleanCypher = Text.Replace(Text.Replace(Text.Replace(Text.Replace(Text.Replace(cypher, "#(cr)", " "), "#(lf)", " "), "\u000d", " "), "\u000a", " "), Character.FromNumber(34), "\""")
     in 
         cleanCypher;
 

--- a/Neo4jPowerBiConnector/Neo4j.query.pq
+++ b/Neo4jPowerBiConnector/Neo4j.query.pq
@@ -14,7 +14,7 @@ in
 
 
 let 
-    result = Neo4j.ExecuteCypher("MATCH (n:Movie) RETURN n", "http", "localhost.", 7474, 3.5, "neo4j", 30)
+    result = Neo4j.ExecuteCypher("MATCH (n:Movie) WHERE n.title = ""The Matrix"" RETURN n", "http", "localhost.", 7474, 2.4, "neo4j", 30)
 in
     result
 


### PR DESCRIPTION
Previously this query:

```
MATCH (m:Movie)
WHERE m.title = "The Matrix"
RETURN m
```

would break as the `"` character wasn't escaped for transmission to Neo4j over REST. This is now fixed.